### PR TITLE
fix: disable override whitelist env for now since the container image is not working correctly

### DIFF
--- a/cdk/ecs.go
+++ b/cdk/ecs.go
@@ -181,7 +181,8 @@ func NewECSResources(scope constructs.Construct, id string, props *ECSResourcesP
 			"VIEW_DISTANCE":                jsii.String(props.MinecraftServerConfig.ViewDistance),
 			"ICON":                         jsii.String(props.MinecraftServerConfig.Icon),
 			"OVERRIDE_ICON":                jsii.String(props.MinecraftServerConfig.OverrideIcon),
-			"OVERRIDE_WHITELIST":           jsii.String(props.MinecraftServerConfig.OverrideWhitelist),
+			// todo(cbrgm): this option is disabled until the flag issue is handled in itzg/minecraft-server-docker
+			// "OVERRIDE_WHITELIST":           jsii.String(props.MinecraftServerConfig.OverrideWhitelist),
 		},
 		PortMappings: &[]*awsecs.PortMapping{
 			{


### PR DESCRIPTION
Not working with the Minecraft 1.21.3
https://github.com/itzg/docker-minecraft-server/blob/e69ee85f8efc078325d29b5e5a41f4d1e013e888/scripts/start-setupRbac#L81