### PR TITLE
fix(cdk): resolve deprecated cdk props and formatting blocking lint

### DIFF
--- a/cdk/awslogs.go
+++ b/cdk/awslogs.go
@@ -85,6 +85,12 @@ func NewQueryLogStack(scope constructs.Construct, id string, props *QueryLogStac
 
 	// Create Lambda function to forward logs
 	logForwarderLambdaID := fmt.Sprintf("%s-LogForwarderLambda", id)
+	// Log group for the forwarder Lambda. Declared explicitly because the
+	// LogRetention property is deprecated in favor of passing a log group.
+	logForwarderLambdaLogGroup := awslogs.NewLogGroup(stack, jsii.String(logForwarderLambdaID+"LogGroup"), &awslogs.LogGroupProps{
+		Retention:     awslogs.RetentionDays_ONE_WEEK,
+		RemovalPolicy: awscdk.RemovalPolicy_DESTROY,
+	})
 	logForwarderLambda := awslambda.NewFunction(stack, jsii.String(logForwarderLambdaID), &awslambda.FunctionProps{
 		FunctionName: jsii.String(logForwarderLambdaID),
 		Code:         awslambda.Code_FromAsset(jsii.String("cmd/lambda/logforwarder"), nil),
@@ -92,7 +98,7 @@ func NewQueryLogStack(scope constructs.Construct, id string, props *QueryLogStac
 		Handler:      jsii.String("bootstrap"),
 		Runtime:      awslambda.Runtime_PROVIDED_AL2023(),
 		Architecture: awslambda.Architecture_ARM_64(),
-		LogRetention: awslogs.RetentionDays_ONE_WEEK,
+		LogGroup:     logForwarderLambdaLogGroup,
 		Environment: &map[string]*string{
 			"TARGET_LOG_GROUP_ARN":  jsii.String(fmt.Sprintf("arn:aws:logs:%s:%s:log-group:%s:*", props.DestinationRegion, props.DestinationAccountId, logGroupName)),
 			"TARGET_LOG_GROUP_NAME": queryLogGroup.LogGroupName(),

--- a/cdk/ecs.go
+++ b/cdk/ecs.go
@@ -49,7 +49,7 @@ func NewECSResources(scope constructs.Construct, id string, props *ECSResourcesP
 	cluster := awsecs.NewCluster(scope, jsii.String(clusterID), &awsecs.ClusterProps{
 		Vpc:                            props.Vpc,
 		ClusterName:                    jsii.String(clusterID),
-		ContainerInsights:              jsii.Bool(true),
+		ContainerInsightsV2:            awsecs.ContainerInsights_ENABLED,
 		EnableFargateCapacityProviders: jsii.Bool(true),
 	})
 

--- a/cdk/lambda.go
+++ b/cdk/lambda.go
@@ -51,6 +51,13 @@ func NewLambdaResources(scope constructs.Construct, id string, props *LambdaReso
 		},
 	})
 
+	// Log group for the launcher Lambda. Declared explicitly because the
+	// LogRetention property is deprecated in favor of passing a log group.
+	launcherLambdaLogGroup := awslogs.NewLogGroup(this, jsii.String(fmt.Sprintf("%s-LauncherLambdaLogGroup", id)), &awslogs.LogGroupProps{
+		Retention:     awslogs.RetentionDays_ONE_WEEK,
+		RemovalPolicy: awscdk.RemovalPolicy_DESTROY,
+	})
+
 	// Create Lambda function using the PROVIDED_AL2023 runtime and x86_64 architecture
 	launcherLambda := awslambda.NewFunction(this, jsii.String(fmt.Sprintf("%s-LauncherLambda", id)), &awslambda.FunctionProps{
 		FunctionName: jsii.String(fmt.Sprintf("%s-LauncherLambda", id)),
@@ -59,7 +66,7 @@ func NewLambdaResources(scope constructs.Construct, id string, props *LambdaReso
 		Handler:      jsii.String("bootstrap"),
 		Runtime:      awslambda.Runtime_PROVIDED_AL2023(),
 		Architecture: awslambda.Architecture_ARM_64(),
-		LogRetention: awslogs.RetentionDays_ONE_WEEK,
+		LogGroup:     launcherLambdaLogGroup,
 		Environment: &map[string]*string{
 			"REGION":  awscdk.Stack_Of(this).Region(),
 			"CLUSTER": props.Cluster.ClusterName(),

--- a/cdk/lambda.go
+++ b/cdk/lambda.go
@@ -70,7 +70,8 @@ func NewLambdaResources(scope constructs.Construct, id string, props *LambdaReso
 	// Add permissions for CloudWatch Logs to invoke Lambda
 	launcherLambda.AddPermission(jsii.String("InvokeLambda"), &awslambda.Permission{
 		Principal: awsiam.NewServicePrincipal(
-			jsii.String(fmt.Sprintf("logs.%s.amazonaws.com", *awscdk.Stack_Of(this).Region())), nil),
+			jsii.String(fmt.Sprintf("logs.%s.amazonaws.com", *awscdk.Stack_Of(this).Region())), nil,
+		),
 		Action:        jsii.String("lambda:InvokeFunction"),
 		SourceArn:     props.QueryLogGroup.LogGroupArn(),
 		SourceAccount: awscdk.Stack_Of(this).Account(),


### PR DESCRIPTION
## What

Fixes the four lint findings that block CI on every PR right now.

- `cdk/ecs.go` -> `ContainerInsights` is deprecated, switched to `ContainerInsightsV2`
- `cdk/lambda.go`, `cdk/awslogs.go` -> `LogRetention` on `FunctionProps` is deprecated, both Lambdas now get an explicit log group
- `cdk/lambda.go` -> one gofumpt formatting fix

## Why

These are pre-existing on `main`, not introduced by any PR. They just show up on every run now -> #617 is red purely because of them.

The `ContainerInsightsV2` change is a pure rename, the synthesized template is byte identical (`ClusterSettings: [{Name: containerInsights, Value: enabled}]` either way).

The `LogRetention` migration is the interesting one. That property is implemented as a custom resource, so dropping it actually removes a backing Lambda, an IAM role and an IAM policy from each stack. Net `-3` resources per stack. Retention stays at 7 days and the group gets `DeletionPolicy: Delete` -> `cdk destroy` still cleans up.

I deliberately did not set `logGroupName`. With an explicit name CloudFormation would collide with the `/aws/lambda/<fn>` group that Lambda already created on a deployed stack. CDK generates a name instead, so a redeploy is clean. Worth knowing: existing log data stays in the old group, new logs go to the new one. The old group keeps whatever retention it has, so delete it by hand if you care.

## Testing

golangci-lint v2.13.1, same version CI resolves, with the repo config:

```
$ golangci-lint run --timeout=10m
0 issues.

$ go build ./... && go vet ./...
$ go test ./...
?   github.com/cbrgm/cdk-on-demand-minecraft-server/cdk                     [no test files]
?   github.com/cbrgm/cdk-on-demand-minecraft-server/cmd/lambda/launcher     [no test files]
?   github.com/cbrgm/cdk-on-demand-minecraft-server/cmd/lambda/logforwarder [no test files]
?   github.com/cbrgm/cdk-on-demand-minecraft-server/cmd/watchdog            [no test files]
```

